### PR TITLE
clean: remove unnecessary annotation

### DIFF
--- a/base-domains/src/main/java/com/example/basedomains/dto/OrderEventDto.java
+++ b/base-domains/src/main/java/com/example/basedomains/dto/OrderEventDto.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 
 @Data
 @AllArgsConstructor
-@RequiredArgsConstructor
 public class OrderEventDto {
     private String message;
     private String status;


### PR DESCRIPTION
Salut, le @RequiredArgsConstructor est inutile car il est deja inclus dans l'annotaion @Data de [lombok](https://projectlombok.org/features/Data)

